### PR TITLE
Fix typo in AEO_0000119

### DIFF
--- a/src/ontology/aeo-edit.obo
+++ b/src/ontology/aeo-edit.obo
@@ -277,7 +277,7 @@ is_a: AEO:0000114 ! epithelial tube
 relationship: has_part CL:0000068 ! duct epithelial cell
 
 [Term]
-id: AEO:0000119f
+id: AEO:0000119
 name: epithelial vesicle
 namespace: http\://www.xspan.org/obo.owl#
 alt_id: EHDAA2:0003119
@@ -1137,7 +1137,7 @@ id: AEO:0001015
 name: somite
 namespace: http\://www.xspan.org/obo.owl#
 def: "An epithelial ball that forms from paraxial mesoderm." [JB:AEO]
-is_a: AEO:0000119f ! epithelial vesicle
+is_a: AEO:0000119 ! epithelial vesicle
 
 [Term]
 id: AEO:0001016

--- a/src/ontology/aeo.owl
+++ b/src/ontology/aeo.owl
@@ -984,9 +984,9 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/AEO_0000119f -->
+    <!-- http://purl.obolibrary.org/obo/AEO_0000119 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/AEO_0000119f">
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/AEO_0000119">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">epithelial vesicle</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CARO_0000066"/>
         <rdfs:subClassOf>
@@ -996,14 +996,14 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A closed epithelium with a lumen.</obo:IAO_0000115>
-        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AEO:0000119f</oboInOwl:id>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AEO:0000119</oboInOwl:id>
         <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EHDAA2:0003119</oboInOwl:hasAlternativeId>
         <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://www.xspan.org/obo.owl#</oboInOwl:hasOBONamespace>
     </owl:Class>
     <owl:Axiom>
         <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A closed epithelium with a lumen.</owl:annotatedTarget>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AEO:JB</oboInOwl:hasDbXref>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/AEO_0000119f"/>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/AEO_0000119"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
     </owl:Axiom>
     
@@ -3282,7 +3282,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/AEO_0001015">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">somite</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/AEO_0000119f"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/AEO_0000119"/>
         <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AEO:0001015</oboInOwl:id>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An epithelial ball that forms from paraxial mesoderm.</obo:IAO_0000115>
         <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://www.xspan.org/obo.owl#</oboInOwl:hasOBONamespace>


### PR DESCRIPTION
This had a trailing `f` for some reason, not following the standard. This was identified in https://github.com/bioregistry/regex-report